### PR TITLE
データ存在範囲確認機能追加

### DIFF
--- a/jaxaEarthApiDialog.py
+++ b/jaxaEarthApiDialog.py
@@ -19,11 +19,13 @@ import webbrowser
 
 # QGIS-API
 from qgis.PyQt import uic
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
-from qgis.core import *
-from qgis.gui import *
+from PyQt5.QtCore import pyqtSignal, QDateTime
+
+# from PyQt5.QtGui import *
+from PyQt5.QtWidgets import QMessageBox, QDialog
+from qgis.core import QgsProject, QgsDateTimeRange
+
+# from qgis.gui import *
 from qgis.utils import iface
 
 # Load module
@@ -312,10 +314,15 @@ class JaxaEarthApiDialog(QDialog):
             return
 
         # check amount of data
-        data_count = len(data.stac_band.url)
+        if hasattr(data, "stac_band") and hasattr(data.stac_band, "url"):
+            data_count = len(data.stac_band.url)
+        else:
+            data_count = 0
 
         if data_count == 0:
-            QMessageBox.information(self, "Error", "No feature found.")
+            QMessageBox.information(
+                self, self.tr("Error"), self.tr("No feature found.")
+            )
             return
 
         if data_count > 0:

--- a/jaxaEarthApiDialog.py
+++ b/jaxaEarthApiDialog.py
@@ -301,7 +301,7 @@ class JaxaEarthApiDialog(QDialog):
                 .filter_resolution()
                 .filter_bounds(bbox=extent)
                 .select(band)
-                .get_images()
+                # .get_images()
             )
         except Exception as e:
             QMessageBox.information(
@@ -311,6 +311,22 @@ class JaxaEarthApiDialog(QDialog):
             )
             print(e)
             return
+
+        print(data.stac_band.url)
+        print(len(data.stac_band.url))
+        print("getting data")
+        try:
+            data = je.ImageCollection.get_images(data)
+        except Exception as e:
+            QMessageBox.information(
+                self,
+                self.tr("Error"),
+                str(e),
+            )
+            print(e)
+            return
+
+        print("data OK")
 
         # Process and show an image
         qgs_layers = je.ImageProcess(data).get_qgis_layers()

--- a/jaxaEarthApiDialog.py
+++ b/jaxaEarthApiDialog.py
@@ -312,9 +312,23 @@ class JaxaEarthApiDialog(QDialog):
             print(e)
             return
 
-        print(data.stac_band.url)
-        print(len(data.stac_band.url))
-        print("getting data")
+        # check amount of data
+        data_count = len(data.stac_band.url)
+
+        if data_count == 0:
+            QMessageBox.information(self, "Error", "No feature found.")
+            return
+
+        if data_count > 0:
+            if QMessageBox.No == QMessageBox.question(
+                None,
+                "Check",
+                f"{data_count} features found.\nLoad it?",
+                QMessageBox.Yes,
+                QMessageBox.No,
+            ):
+                return
+
         try:
             data = je.ImageCollection.get_images(data)
         except Exception as e:
@@ -325,8 +339,6 @@ class JaxaEarthApiDialog(QDialog):
             )
             print(e)
             return
-
-        print("data OK")
 
         # Process and show an image
         qgs_layers = je.ImageProcess(data).get_qgis_layers()

--- a/jaxaEarthApiDialog.py
+++ b/jaxaEarthApiDialog.py
@@ -21,11 +21,9 @@ import webbrowser
 from qgis.PyQt import uic
 from PyQt5.QtCore import pyqtSignal, QDateTime
 
-# from PyQt5.QtGui import *
 from PyQt5.QtWidgets import QMessageBox, QDialog
 from qgis.core import QgsProject, QgsDateTimeRange
 
-# from qgis.gui import *
 from qgis.utils import iface
 
 # Load module

--- a/jaxaEarthApiDialog.py
+++ b/jaxaEarthApiDialog.py
@@ -301,7 +301,6 @@ class JaxaEarthApiDialog(QDialog):
                 .filter_resolution()
                 .filter_bounds(bbox=extent)
                 .select(band)
-                # .get_images()
             )
         except Exception as e:
             QMessageBox.information(


### PR DESCRIPTION
## Issue
<!-- close or related -->
close #0

## 変更内容:Description
<!-- タイトル以上の詳細が必要なら記載 -->
API結果のデータ件数を確認し、それを確認MessageBoxでユーザーがレイヤ化にするかを判断
![image](https://github.com/MIERUNE/qgis-jaxa-earth-plugin/assets/26103833/7664733a-47f1-4d47-b5ce-2f25dcb537d4)


## テスト手順:Test
<!-- 手動で動作確認する必要があるなら記載 -->
- Loadしてみて以下を確認
  - Yesにして処理が進む
  - Noにして処理が止まる


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - データセットの読み込み時にデータの量を確認し、データが見つからない場合はエラーメッセージを表示する機能を追加しました。
  - データが見つかった場合には、データを読み込む前に確認ダイアログを表示する機能を追加しました。
  - 画像取得時のエラーを処理するための例外処理ブロックを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->