### PR TITLE
Feat/display available period

### DIFF
--- a/jaxaEarthApiDialog.py
+++ b/jaxaEarthApiDialog.py
@@ -166,6 +166,9 @@ class JaxaEarthApiDialog(QDialog):
     def reload_band_combobox(self):
         self.bandCombobox.clear()
         if self.datasetCombobox.currentData() is None:
+            # Show no period available
+            self.label_start_available_period.setText("-")
+            self.label_end_available_period.setText("-")
             return
 
         dataset_info = self.datasetCombobox.currentData()
@@ -183,7 +186,19 @@ class JaxaEarthApiDialog(QDialog):
         ]
 
         interval_start_time = dataset_info["temporal"][0][0]
-        interval_end_time = dataset_info["temporal"][0][1]  # str
+        interval_end_time = dataset_info["temporal"][0][1]  # str 2012-01-01T00:00:00Z
+
+        # set avalaible period as text in UI
+        self.label_start_available_period.setText(interval_start_time.split("T")[0])
+
+        if interval_end_time:
+            interval_end_time_txt = interval_end_time.split("T")[0]
+        else:
+            # set today when end time is not defined
+            today = datetime.datetime.today()
+            interval_end_time_txt = today.strftime("%Y-%m-%d")
+
+        self.label_end_available_period.setText(interval_end_time_txt)
 
         interval_start_time_obj = datetime.datetime.strptime(
             interval_start_time, "%Y-%m-%dT%H:%M:%SZ"

--- a/jaxaEarthApiDialog.ui
+++ b/jaxaEarthApiDialog.ui
@@ -187,7 +187,45 @@
       </item>
      </layout>
     </item>
-    <item row="3" column="1">
+    <item row="3" column="1" colspan="2">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="label_avalaibleperiod">
+        <property name="text">
+         <string>Avalaible period: </string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_start_available_period">
+        <property name="text">
+         <string>-</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>-&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_start_available_period">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>-</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="4" column="1">
      <widget class="QgsExtentGroupBox" name="mExtentGroupBox"/>
     </item>
    </layout>

--- a/jaxaEarthApiDialog.ui
+++ b/jaxaEarthApiDialog.ui
@@ -211,7 +211,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="label_start_available_period">
+       <widget class="QLabel" name="label_end_available_period">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>


### PR DESCRIPTION
## Issue
<!-- close or related -->
close #0

## 変更内容:Description
<!-- タイトル以上の詳細が必要なら記載 -->
- Display available period of each dataset

![image](https://github.com/MIERUNE/qgis-jaxa-earth-plugin/assets/26103833/74fb9090-45ac-4f86-8477-91a9b29f1cfd)


## テスト手順:Test
<!-- 手動で動作確認する必要があるなら記載 -->
- Choose dataset
- Check available period
- Test to load data (especially newest 2023 2024 data if available)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - データセット情報に基づいて利用可能な期間の開始時刻と終了時刻を表示するためのUIラベルを追加しました。終了時刻が定義されていない場合、デフォルトで現在の日付が設定されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->