### PR TITLE
Fix dataset details based url

### DIFF
--- a/jaxaEarthApiDialog.py
+++ b/jaxaEarthApiDialog.py
@@ -401,5 +401,5 @@ class JaxaEarthApiDialog(QDialog):
 
     def show_details(self):
         dataset_name = self.datasetCombobox.currentData()["key"]
-        webbrowser.open(f"https://data.earth.jaxa.jp/en/datasets/#/id/{dataset_name}")
+        webbrowser.open(f"https://data.earth.jaxa.jp/app/qgis/datasets/#{dataset_name}")
         return


### PR DESCRIPTION
## Issue
<!-- close or related -->
close #0

## 変更内容:Description
<!-- タイトル以上の詳細が必要なら記載 -->
- Fix dataset details based url

## テスト手順:Test
<!-- 手動で動作確認する必要があるなら記載 -->
- Click details button and check browser


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `show_details` メソッドで開かれるURLを更新しました。新しいURLは `"https://data.earth.jaxa.jp/app/qgis/datasets/#{dataset_name}"` です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->