### PR TITLE
Feat/get catalog online

### DIFF
--- a/catalog/loader.py
+++ b/catalog/loader.py
@@ -9,14 +9,16 @@ def get_catalog() -> dict:
     unused in plugin
     this method needs too long time to run everytime on launch plugin
     run when build this plugin and make dictionary with output of this script
+    UPDATE 2024-05-30 : catalog can be retrieved through following URL:
+    https://data.earth.jaxa.jp/app/qgis/catalog.json
+    This script to be used only when above URL does not work.
     """
     catalog = {}
 
     res = requests.get(STAC_CATALOG_URL)
     res_json = res.json()
 
-    children = list(
-        filter(lambda d: d["rel"] == "child", res_json.get("links", [])))
+    children = list(filter(lambda d: d["rel"] == "child", res_json.get("links", [])))
     for child in children:
         res_child = requests.get(child["href"])
         res_child_json = res_child.json()
@@ -33,12 +35,12 @@ def get_catalog() -> dict:
             "bands": dataset_bands,
             "keywords": dataset_keywords,
             "bbox": dataset_bbox,
-            "temporal": dataset_temporal
+            "temporal": dataset_temporal,
         }
     return catalog
 
 
 if __name__ == "__main__":
     catalog = get_catalog()
-    with open('./catalog.json', mode='w') as f:
+    with open("./catalog.json", mode="w") as f:
         json.dump(catalog, f, ensure_ascii=False)

--- a/jaxaEarthApiDialog.py
+++ b/jaxaEarthApiDialog.py
@@ -1,8 +1,8 @@
 """
 /***************************************************************************
- Sample
+ JAXA Earth API Plugin
                                  A QGIS plugin
- QGIS Sample Plugin
+ QGIS Plugin for JAXA Earth API, easily get satellite datasets.
                               -------------------
         begin                : 2021-06-30
         git sha              : $Format:%H$

--- a/jaxaEarthApiDialog.py
+++ b/jaxaEarthApiDialog.py
@@ -16,6 +16,7 @@ import os
 import json
 import datetime
 import webbrowser
+import requests
 
 # QGIS-API
 from qgis.PyQt import uic
@@ -29,8 +30,37 @@ from qgis.utils import iface
 # Load module
 from .jaxa.earth import je
 
-with open(os.path.join(os.path.dirname(__file__), "catalog.json")) as f:
-    CATALOG = json.load(f)
+# Load jaxa dataset catalog
+CATALOG_URL = "https://data.earth.jaxa.jp/app/qgis/catalog.json"
+
+try:
+    response = requests.get(CATALOG_URL)
+    if response.status_code == 200:
+        CATALOG = response.json()
+        print(response)
+    else:
+        message = "Could not load catalog.json\n"
+        message += f"Response {response.status_code} \nLoad local catalog"
+        QMessageBox.information(
+            None,
+            "JAXA Earth API Plugin - Warning",
+            message,
+        )
+        # Fallback load local catalog
+        with open(os.path.join(os.path.dirname(__file__), "catalog.json")) as f:
+            CATALOG = json.load(f)
+except Exception as e:
+    message = "Could not load catalog.json\n"
+    message += f"{str(e)} \nLoad local catalog"
+    QMessageBox.information(
+        None,
+        "JAXA Earth API Plugin - Warning",
+        message,
+    )
+    print(e)
+    # Fallback load local catalog
+    with open(os.path.join(os.path.dirname(__file__), "catalog.json")) as f:
+        CATALOG = json.load(f)
 
 
 def parse_jaxa_dateid(date_id: str, year=None) -> (int, int, int):

--- a/jaxaEarthApiDialog.py
+++ b/jaxaEarthApiDialog.py
@@ -34,7 +34,7 @@ from .jaxa.earth import je
 CATALOG_URL = "https://data.earth.jaxa.jp/app/qgis/catalog.json"
 
 try:
-    response = requests.get(CATALOG_URL)
+    response = requests.get(CATALOG_URL, timeout=60)
     if response.status_code == 200:
         CATALOG = response.json()
         print(response)

--- a/jaxaEarthApiPlugin.py
+++ b/jaxaEarthApiPlugin.py
@@ -2,7 +2,7 @@
 /***************************************************************************
  Sample
                                  A QGIS plugin
- QGIS Sample Plugin
+ QGIS Plugin for JAXA Earth API, easily get satellite datasets.
                               -------------------
         begin                : 2021-06-30
         git sha              : $Format:%H$
@@ -39,11 +39,10 @@ class JaxaEarthApiPlugin:
         self.dialog = None
         self.action = None
         # initialize locale
-        locale = QSettings().value('locale/userLocale')[0:2]
+        locale = QSettings().value("locale/userLocale")[0:2]
         locale_path = os.path.join(
-            self.plugin_dir,
-            'i18n',
-            'jaxaEarthApi_{}.qm'.format(locale))
+            self.plugin_dir, "i18n", "jaxaEarthApi_{}.qm".format(locale)
+        )
 
         if os.path.exists(locale_path):
             self.translator = QTranslator()

--- a/jaxaEarthApiPlugin.py
+++ b/jaxaEarthApiPlugin.py
@@ -1,6 +1,6 @@
 """
 /***************************************************************************
- Sample
+ JAXA Earth API Plugin
                                  A QGIS plugin
  QGIS Plugin for JAXA Earth API, easily get satellite datasets.
                               -------------------


### PR DESCRIPTION
## Issue
<!-- close or related -->
close #0

## 変更内容:Description
<!-- タイトル以上の詳細が必要なら記載 -->
- catalog.jsonをOnlineで取得
- 取得できない場合、Localのcatalog.jsonを取得

## テスト手順:Test
<!-- 手動で動作確認する必要があるなら記載 -->
以下を確認
- Dataset を取得できる
- ネットワークを切ってPlugin reloaderを実行したら、取得できないMessageが来て、Localのcatalog.jsonを取得
※現状localとcloudのCatalogが 一緒はずなので、テストのためにLocalのcatalog.jsonの一件の名前を変更して比較できます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - JAXA Earth API PluginがリモートURLからカタログデータを動的に読み込む機能を追加しました。リモートカタログを読み込めない場合、ローカルカタログファイルにフォールバックします。

- **改善**
  - プラグイン名を「JAXA Earth API Plugin」に変更しました。
  - ロケール設定の文字列フォーマットを改善しました。

- **バグ修正**
  - カタログ取得時のURLを更新し、リモートカタログが利用できない場合のエラーメッセージとフォールバック処理を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->